### PR TITLE
Some additional debug logs in the loader.

### DIFF
--- a/src/Shared-Src/Native/loader.cpp
+++ b/src/Shared-Src/Native/loader.cpp
@@ -1095,8 +1095,9 @@ namespace shared {
       return S_OK;
     }
 
-    bool Loader::GetAssemblyAndSymbolsBytes(void** pAssemblyArray, int* assemblySize,
-                                            void** pSymbolsArray, int* symbolsSize,
+    bool Loader::GetAssemblyAndSymbolsBytes(void** pAssemblyArray,
+                                            int* assemblySize, void** pSymbolsArray,
+                                            int* symbolsSize,
                                             AppDomainID appDomainId) {
         //
         // global lock

--- a/src/Shared-Src/Native/loader.h
+++ b/src/Shared-Src/Native/loader.h
@@ -148,8 +148,7 @@ namespace shared {
 		HRESULT InjectLoaderToModuleInitializer(const ModuleID module_id);
 
 		bool GetAssemblyAndSymbolsBytes(void** pAssemblyArray, int* assemblySize,
-                                        void** pSymbolsArray, int* symbolsSize,
-                                        AppDomainID appDomainId);
+			void** pSymbolsArray, int* symbolsSize, AppDomainID appDomainId);
 
 		static Loader* CreateLoader(
 			ICorProfilerInfo4* info,


### PR DESCRIPTION
I was debugging an issue related to incorrectly setting the resource IDs and these additional log statements were useful. I suggest we keep them.

In addition, should `Loader::GetAssemblyAndSymbolsBytes(..)` return `false` if it cannot find the resource? (potential separate PR)
 