### PR TITLE
remove individual users from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-﻿* @macrogreg @DataDog/apm-dotnet
+﻿* @DataDog/apm-dotnet


### PR DESCRIPTION
As general policy, we use GitHub teams in the `CODEOWNERS` file, not individual users. This allows us to manage the code owners by modifying team members instead of making changes to the file. For example, adding/removing members from teams is (mostly) automated when employees are onboarded/offboarded.

`macrogreg` is a member of `DataDog/apm-dotnet` so this shouldn't make any difference in term of required approvals.