### PR TITLE
Rename the binary output folder ".build" to "_build" to avoid issues with hidden files on Linux.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -77,7 +77,7 @@
     <!--                                                                                                                                                    -->
     <!--     c:\00\Code\GitHub\                                 <== Root for your code repos                                                                -->
     <!--            DD-DotNet\                                  <== A shared folder collecting one or more repors that "build together" in a group          -->
-    <!--                    .build\                             <== Root folder for build output for ALL repos in this group                                -->
+    <!--                    _build\                             <== Root folder for build output for ALL repos in this group                                -->
     <!--                            bin\                                                                                                                    -->
     <!--                                . . .                                                                                                               -->
     <!--                            obj\                                                                                                                    -->
@@ -100,19 +100,19 @@
         
         <AvoidRedirectingBinaryOutput>false</AvoidRedirectingBinaryOutput>
         
-        <!-- Set ForceBinaryOutputIntoEnlistment to True to redirect all binary output into a ".build\" directory WITHIN the repository root,               -->
+        <!-- Set ForceBinaryOutputIntoEnlistment to True to redirect all binary output into a "_build\" directory WITHIN the repository root,               -->
         <!-- instead of having that directory as a neighbour NEXT TO the repo root.                                                                         -->
         <!-- This is not recommended in general, but it can be useful if repo enlistments are all contained within the same parent directory without the    -->
         <!-- intermediate project monikers described above. In that case, this will ensure that binaries from different repository copies are separated.    -->
         <!-- (This may not work with multi-repo buld-groups.)                                                                                               -->
-        <!-- If you use this option, make sure to add ".build\" to your .gitignore.                                                                         -->
+        <!-- If you use this option, make sure to add "_build\" to your .gitignore.                                                                         -->
         
         <ForceBinaryOutputIntoEnlistment>false</ForceBinaryOutputIntoEnlistment>
         
         <!-- Use BuildOutputFolderName to contril the the name of the folder that contains all the redirected binary output.                                -->
         <!-- It is placed as a sibling of the repo root (default), or directly within the repo root (see the ForceBinaryOutputIntoEnlistment property).     -->
         
-        <BuildOutputFolderName>.build</BuildOutputFolderName>
+        <BuildOutputFolderName>_build</BuildOutputFolderName>
 
         <!-- Set PrintDetailedOutputRedirectionInfo to true/false to control whether detailed output is printed during the build.                           -->
         <!-- Use "false" if the details are too verbose for your needs.                                                                                     -->
@@ -125,7 +125,7 @@
     <PropertyGroup Condition=" '$(AvoidRedirectingBinaryOutput)' != 'True' ">
     
         <!-- EnlistmentRoot is the root folder of the repository. Typically, it is the folder that contains the ".git\" subfolder.                          -->
-        <!-- The binary output root directories ("bin\" and "obj\") will be typically placed placed into a ".build\" directory immediately above it.        -->
+        <!-- The binary output root directories ("bin\" and "obj\") will be typically placed placed into a "_build\" directory immediately above it.        -->
         <!-- You can use ForceBinaryOutputIntoEnlistment to control that behaviour.                                                                         -->
         <EnlistmentRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '.EnlistmentRoot.marker'))</EnlistmentRoot>
         

--- a/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/LateLoadDS.NetFx/Datadog.DynamicDiagnosticSourceBindings.Demo.LateLoadDS.NetFx.csproj
+++ b/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/LateLoadDS.NetFx/Datadog.DynamicDiagnosticSourceBindings.Demo.LateLoadDS.NetFx.csproj
@@ -33,18 +33,18 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\.build\ImportedPackages\System.Buffers.4.5.1\lib\netstandard1.1\System.Buffers.dll</HintPath>
+      <HintPath>..\..\..\..\_build\ImportedPackages\System.Buffers.4.5.1\lib\netstandard1.1\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=5.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\.build\ImportedPackages\System.Diagnostics.DiagnosticSource.5.0.1\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\_build\ImportedPackages\System.Diagnostics.DiagnosticSource.5.0.1\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\.build\ImportedPackages\System.Memory.4.5.4\lib\netstandard1.1\System.Memory.dll</HintPath>
+      <HintPath>..\..\..\..\_build\ImportedPackages\System.Memory.4.5.4\lib\netstandard1.1\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\.build\ImportedPackages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\..\..\..\_build\ImportedPackages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/NuGet.config
+++ b/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/NuGet.config
@@ -17,6 +17,6 @@
     <clear />
   </disabledPackageSources>
   <config>
-    <add key="RepositoryPath" value="../../../.build/ImportedPackages" />
+    <add key="RepositoryPath" value="../../../_build/ImportedPackages" />
   </config>
 </configuration>

--- a/src/Shared-Src/Datadog.Util/internal/ExceptionAggregator.cs
+++ b/src/Shared-Src/Datadog.Util/internal/ExceptionAggregator.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+
+namespace Datadog.Util
+{
+    internal ref struct ExceptionAggregator
+    {
+        private object _aggregator;
+
+        public bool IsEmpty
+        {
+            get { return (_aggregator == null); }
+        }
+
+        public int Count
+        {
+            get
+            {
+                if (_aggregator == null)
+                {
+                    return 0;
+                }
+                else if (_aggregator is Exception)
+                {
+                    return 1;
+                }
+                else
+                {
+                    List<Exception> prevList = (List<Exception>) _aggregator;
+                    return prevList.Count;
+                }
+            }
+        }
+
+        public void Add(Exception exception)
+        {
+            if (exception == null)
+            {
+                return;
+            }
+
+            if (_aggregator == null)
+            {
+                _aggregator = exception;
+                return;
+            }
+
+            if (_aggregator is Exception prevException)
+            {
+                var aggr = new List<Exception>();
+                aggr.Add(prevException);
+                aggr.Add(exception);
+                _aggregator = aggr;
+                return;
+            }
+
+            List<Exception> prevList = (List<Exception>) _aggregator;
+            prevList.Add(exception);
+        }
+
+        public bool TryGetAggregatedException(out Exception exception)
+        {
+            return TryGetAggregatedException(aggregateExceptionMessage: null, out exception);
+        }
+
+        public bool TryGetAggregatedException(string aggregateExceptionMessage, out Exception exception)
+        {
+            if (_aggregator == null)
+            {
+                exception = null;
+                return false;
+            }
+
+            if (_aggregator is Exception prevException)
+            {
+                exception = prevException;
+                return true;
+            }
+
+            List<Exception> prevList = (List<Exception>) _aggregator;
+            exception = (aggregateExceptionMessage == null)
+                                ? new AggregateException(prevList)
+                                : new AggregateException(aggregateExceptionMessage, prevList);
+            return true;
+        }
+
+        public void ThrowIfNotEmpty()
+        {
+            ThrowIfNotEmpty(aggregateExceptionMessage: null);
+        }
+
+        public void ThrowIfNotEmpty(string aggregateExceptionMessage)
+        {
+            if (_aggregator == null)
+            {
+                return;
+            }
+
+            if (_aggregator is Exception prevException)
+            {
+                prevException.Rethrow();
+            }
+
+            List<Exception> prevList = (List<Exception>) _aggregator;
+            AggregateException aggEx = (aggregateExceptionMessage == null)
+                                            ? new AggregateException(prevList)
+                                            : new AggregateException(aggregateExceptionMessage, prevList);
+            throw aggEx;
+        }
+    }
+}


### PR DESCRIPTION
This PR is incremental to https://github.com/DataDog/dd-shared-components-dotnet/pull/7