### PR TITLE
Managed Assemblies To Load passed as parameters to the loader.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -151,7 +151,7 @@
         <!-- By default, Platform is AnyCPU, but user can (and may) overwrite it.                                                                       -->
         <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
 
-        <!-- ConfigBasedRelativeOutputPath is the relative subdir such as "Debug\x64" or "Release\netcoreapp3.1" or similar within the project              -->
+        <!-- ConfigBasedRelativeOutputPath is the relative subdir such as "Debug-AnyCPU" or "Release-x64" or similar within the project              -->
         <ConfigBasedRelativeOutputPath>$(Configuration)</ConfigBasedRelativeOutputPath>
         <ConfigBasedRelativeOutputPath Condition=" '$(Platform)' != '' ">$(ConfigBasedRelativeOutputPath)-$(Platform)</ConfigBasedRelativeOutputPath>
 
@@ -254,6 +254,7 @@
 
         <Message Text="[$(RdrctOutptMsgPrefix)]     Configuration:                   &quot;$(Configuration)&quot;." Importance="high" />
         <Message Text="[$(RdrctOutptMsgPrefix)]     Platform:                        &quot;$(Platform)&quot;." Importance="high" />
+        <Message Text="[$(RdrctOutptMsgPrefix)]     PlatformTarget:                  &quot;$(PlatformTarget)&quot;." Importance="high" />
         <Message Text="[$(RdrctOutptMsgPrefix)]     TargetFramework:                 &quot;$(TargetFramework)&quot;." Importance="high" />
         <Message Text="[$(RdrctOutptMsgPrefix)]     RuntimeIdentifier:               &quot;$(RuntimeIdentifier)&quot;." Importance="high" />
         <Message Text="[$(RdrctOutptMsgPrefix)]     ConfigBasedRelativeOutputPath:   &quot;$(ConfigBasedRelativeOutputPath)&quot;." Importance="high" />

--- a/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
+++ b/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
@@ -387,8 +387,8 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
         private static void GetProfilerManagedBinariesDirectories(List<string> binaryDirs)
         {
             // Assumed folder structure
-            // (support both options for now; be aware tha tgis may change while we are still in Alpha):
-            // OPTION A (SxS with Tracer):
+            // (support the below options for now; be aware that this may change while we are still in Alpha):
+            // OPTION A (SxS Profiler & Tracer):
             //  - c:\Program Files\Datadog\.NET Tracer\                                     <= Native Tracer/Profiler loader binary
             //  - c:\Program Files\Datadog\.NET Tracer\                                     <= Also, native Tracer binaries for Win-x64
             //  - c:\Program Files\Datadog\.NET Tracer\net45\                               <= Managed Tracer binaries for Net Fx 4.5
@@ -402,6 +402,10 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
             //  - c:\Program Files\Datadog\Some Dir\net45\                                  <= Managed Profiler binaries for Net Fx 4.5
             //  - c:\Program Files\Datadog\Some Dir\netcoreapp3.1\                          <= Managed Profiler binaries for Net Core 3.1 +
             //  - ...
+            // OPTION C (Debug builds only!):
+            //  - Use the relavite path from where our build places the native profiler engine DLL to where the build 
+            //    places the managed profiler engine DLL.
+            //  - This is for F5-running from within VS.
 
             string managedBinariesSubdir = GetRuntimeBasedProductBinariesSubdir(out bool isCoreFx);
 
@@ -452,8 +456,9 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
 
 #if DEBUG
             {
+                // OPTION C (Debug builds only!):
                 // For debug builds only we also support F5-running from within VS.
-                // For that we use the relavite path from where our build places the native profiler engine DLL to where the build process
+                // For that we use the relavite path from where our build places the native profiler engine DLL to where the build
                 // places the managed profiler engine DLL.
                 const string NativeToManagedRelativePath = @"..\..\..\Debug-AnyCPU\ProfilerEngine\Datadog.AutoInstrumentation.Profiler.Managed\";
 
@@ -477,7 +482,7 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
                     binaryDirs.Add(managedBinariesDirectory);
                 }
             }
-#endif
+#endif  // #if DEBUG
         }
 
         private static string GetRuntimeBasedProductBinariesSubdir()

--- a/src/Shared-Src/Native/loader.cpp
+++ b/src/Shared-Src/Native/loader.cpp
@@ -27,8 +27,6 @@ namespace shared {
 #endif
     
     const WSTRING managed_loader_assembly_name                  = WStr("Datadog.AutoInstrumentation.ManagedLoader");
-    const WSTRING empty_string                                  = WStr("");
-    const WSTRING default_domain_name                           = WStr("DefaultDomain");
 
     const LPCWSTR managed_loader_startup_type                   = WStr("Datadog.AutoInstrumentation.ManagedLoader.AssemblyLoader");
     const LPCWSTR module_type_name                              = WStr("<Module>");
@@ -54,10 +52,6 @@ namespace shared {
     const LPCWSTR invoke_name                                   = WStr("Invoke");
     const LPCWSTR run_name                                      = WStr("Run");
     
-    const WSTRING profiler_path_64                              = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH_64"));
-    const WSTRING profiler_path_32                              = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH_32"));
-    const WSTRING profiler_path                                 = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH"));
-
     // We exclude here the direct references of the loader to avoid a cyclic reference problem.
     // Also well-known assemblies we want to avoid.
     const WSTRING assemblies_exclusion_list_[] = {
@@ -79,13 +73,18 @@ namespace shared {
     };
 
     void Loader::CreateNewSingeltonInstance(ICorProfilerInfo4* pCorProfilerInfo,
-                                            std::function<void(const std::string& str)> logDebugCallback,
-                                            std::function<void(const std::string& str)> logInfoCallback,
-                                            std::function<void(const std::string& str)> logWarnCallback,
-                                            const LoaderResourceMonikerIDs& resourceMonikerIDs,
+                                            std::function<void(const std::string& str)> log_debug_callback,
+                                            std::function<void(const std::string& str)> log_info_callback,
+                                            std::function<void(const std::string& str)> log_warn_callback,
+                                            const LoaderResourceMonikerIDs& resource_moniker_ids,
                                             WCHAR const * native_profiler_library_filename)
     {
-        Loader* newSingeltonInstance = Loader::CreateNewLoaderInstance(pCorProfilerInfo, logDebugCallback, logInfoCallback, logWarnCallback, resourceMonikerIDs, native_profiler_library_filename);
+        Loader* newSingeltonInstance = Loader::CreateNewLoaderInstance(pCorProfilerInfo,
+                                                                       log_debug_callback,
+                                                                       log_info_callback, 
+                                                                       log_warn_callback, 
+                                                                       resource_moniker_ids, 
+                                                                       native_profiler_library_filename);
 
         Loader::DeleteSingeltonInstance();
         Loader::s_singeltonInstance = newSingeltonInstance;
@@ -113,7 +112,7 @@ namespace shared {
     }
 
     Loader* Loader::CreateNewLoaderInstance(
-        ICorProfilerInfo4* info,
+        ICorProfilerInfo4* pCorProfilerInfo,
         std::function<void(const std::string& str)> log_debug_callback,
         std::function<void(const std::string& str)> log_info_callback,
         std::function<void(const std::string& str)> log_warn_callback,
@@ -148,7 +147,7 @@ namespace shared {
 
         }
 
-        return new Loader(info,
+        return new Loader(pCorProfilerInfo,
             assembly_string_default_appdomain_vector,
             assembly_string_nondefault_appdomain_vector,
             log_debug_callback,

--- a/src/Shared-Src/Native/loader.h
+++ b/src/Shared-Src/Native/loader.h
@@ -95,7 +95,7 @@ namespace shared {
 		static Loader* s_singeltonInstance;
 
 		static Loader* CreateNewLoaderInstance(
-			ICorProfilerInfo4* info,
+			ICorProfilerInfo4* pCorProfilerInfo,
 			std::function<void(const std::string& str)> log_debug_callback,
 			std::function<void(const std::string& str)> log_info_callback,
 			std::function<void(const std::string& str)> log_warn_callback,
@@ -152,10 +152,10 @@ namespace shared {
 	public:
 		
 		static void CreateNewSingeltonInstance(ICorProfilerInfo4* pCorProfilerInfo,
-                                               std::function<void(const std::string& str)> logDebugCallback,
-			                                   std::function<void(const std::string& str)> logInfoCallback,
-                                               std::function<void(const std::string& str)> logWarnCallback,
-                                               const LoaderResourceMonikerIDs& resourceMonikerIDs,
+                                               std::function<void(const std::string& str)> log_debug_callback,
+			                                   std::function<void(const std::string& str)> log_info_callback,
+                                               std::function<void(const std::string& str)> log_warn_callback,
+                                               const LoaderResourceMonikerIDs& resource_moniker_ids,
 			                                   WCHAR const * native_profiler_library_filename);
 		static Loader* GetSingeltonInstance();
 		static void DeleteSingeltonInstance(void);

--- a/src/Shared-Src/Native/loader.h
+++ b/src/Shared-Src/Native/loader.h
@@ -15,156 +15,167 @@
 
 namespace shared {
 
-	struct RuntimeInfo {
-		COR_PRF_RUNTIME_TYPE runtime_type;
-		USHORT major_version;
-		USHORT minor_version;
-		USHORT build_version;
-		USHORT qfe_version;
+    struct RuntimeInfo {
+        COR_PRF_RUNTIME_TYPE runtime_type;
+        USHORT major_version;
+        USHORT minor_version;
+        USHORT build_version;
+        USHORT qfe_version;
 
-		RuntimeInfo()
-			: runtime_type((COR_PRF_RUNTIME_TYPE)0x0),
-			major_version(0),
-			minor_version(0),
-			build_version(0),
-			qfe_version(0) {}
+        RuntimeInfo()
+            : runtime_type((COR_PRF_RUNTIME_TYPE)0x0),
+            major_version(0),
+            minor_version(0),
+            build_version(0),
+            qfe_version(0) {}
 
-		RuntimeInfo(COR_PRF_RUNTIME_TYPE runtime_type, USHORT major_version,
-			USHORT minor_version, USHORT build_version, USHORT qfe_version)
-			: runtime_type(runtime_type),
-			major_version(major_version),
-			minor_version(minor_version),
-			build_version(build_version),
-			qfe_version(qfe_version) {}
+        RuntimeInfo(COR_PRF_RUNTIME_TYPE runtime_type, USHORT major_version,
+            USHORT minor_version, USHORT build_version, USHORT qfe_version)
+            : runtime_type(runtime_type),
+            major_version(major_version),
+            minor_version(minor_version),
+            build_version(build_version),
+            qfe_version(qfe_version) {}
 
-		RuntimeInfo& operator=(const RuntimeInfo& other) {
-			runtime_type = other.runtime_type;
-			major_version = other.major_version;
-			minor_version = other.minor_version;
-			build_version = other.build_version;
-			qfe_version = other.qfe_version;
-			return *this;
-		}
+        RuntimeInfo& operator=(const RuntimeInfo& other) {
+            runtime_type = other.runtime_type;
+            major_version = other.major_version;
+            minor_version = other.minor_version;
+            build_version = other.build_version;
+            qfe_version = other.qfe_version;
+            return *this;
+        }
 
-		bool is_desktop() const { return runtime_type == COR_PRF_DESKTOP_CLR; }
-		bool is_core() const { return runtime_type == COR_PRF_CORE_CLR; }
-	};
+        bool is_desktop() const { return runtime_type == COR_PRF_DESKTOP_CLR; }
+        bool is_core() const { return runtime_type == COR_PRF_CORE_CLR; }
+    };
 
-	struct LoaderResourceMonikerIDs
-	{
-		public:
-			LoaderResourceMonikerIDs(void)
+    struct LoaderResourceMonikerIDs
+    {
+        public:
+            LoaderResourceMonikerIDs(void)
                 : Net45_Datadog_AutoInstrumentation_ManagedLoader_dll(0),
-				  NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_dll(0),
-				  Net45_Datadog_AutoInstrumentation_ManagedLoader_pdb(0),
-				  NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_pdb(0)
-			{}
+                  NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_dll(0),
+                  Net45_Datadog_AutoInstrumentation_ManagedLoader_pdb(0),
+                  NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_pdb(0)
+            {}
 
-			LoaderResourceMonikerIDs(const LoaderResourceMonikerIDs& ids)
-				: Net45_Datadog_AutoInstrumentation_ManagedLoader_dll(ids.Net45_Datadog_AutoInstrumentation_ManagedLoader_dll),
-				  NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_dll(ids.NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_dll),
-			   	  Net45_Datadog_AutoInstrumentation_ManagedLoader_pdb(ids.Net45_Datadog_AutoInstrumentation_ManagedLoader_pdb),
-				  NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_pdb(ids.NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_pdb)
-			{}
+            LoaderResourceMonikerIDs(const LoaderResourceMonikerIDs& ids)
+                : Net45_Datadog_AutoInstrumentation_ManagedLoader_dll(ids.Net45_Datadog_AutoInstrumentation_ManagedLoader_dll),
+                  NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_dll(ids.NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_dll),
+                     Net45_Datadog_AutoInstrumentation_ManagedLoader_pdb(ids.Net45_Datadog_AutoInstrumentation_ManagedLoader_pdb),
+                  NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_pdb(ids.NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_pdb)
+            {}
 
-			std::int32_t Net45_Datadog_AutoInstrumentation_ManagedLoader_dll;
-			std::int32_t NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_dll;
-			std::int32_t Net45_Datadog_AutoInstrumentation_ManagedLoader_pdb;
-			std::int32_t NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_pdb;
-	};
+            std::int32_t Net45_Datadog_AutoInstrumentation_ManagedLoader_dll;
+            std::int32_t NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_dll;
+            std::int32_t Net45_Datadog_AutoInstrumentation_ManagedLoader_pdb;
+            std::int32_t NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_pdb;
+    };
 
-	class Loader {
-	private:
-		RuntimeInfo runtime_information_;
-		ICorProfilerInfo4* info_;
+    class Loader {
+    private:
+        RuntimeInfo runtime_information_;
+        ICorProfilerInfo4* info_;
 
-		std::mutex loaders_loaded_mutex_;
-		std::unordered_set<AppDomainID> loaders_loaded_;
+        std::mutex loaders_loaded_mutex_;
+        std::unordered_set<AppDomainID> loaders_loaded_;
 
-		std::vector<WSTRING> assembly_string_default_appdomain_vector_;
-		std::vector<WSTRING> assembly_string_nondefault_appdomain_vector_;
+        std::vector<WSTRING> assembly_string_default_appdomain_vector_;
+        std::vector<WSTRING> assembly_string_nondefault_appdomain_vector_;
 
-		std::function<void(const std::string& str)> log_debug_callback_ = nullptr;
-		std::function<void(const std::string& str)> log_info_callback_ = nullptr;
-		std::function<void(const std::string& str)> log_warn_callback_ = nullptr;
+        std::function<void(const std::string& str)> log_debug_callback_ = nullptr;
+        std::function<void(const std::string& str)> log_info_callback_ = nullptr;
+        std::function<void(const std::string& str)> log_warn_callback_ = nullptr;
 
-		LoaderResourceMonikerIDs resourceMonikerIDs_;
+        LoaderResourceMonikerIDs resourceMonikerIDs_;
 
-		WCHAR const* native_profiler_library_filename_;
+        WCHAR const* native_profiler_library_filename_;
 
-		static Loader* s_singeltonInstance;
+        static Loader* s_singeltonInstance;
 
-		static Loader* CreateNewLoaderInstance(
-			ICorProfilerInfo4* pCorProfilerInfo,
-			std::function<void(const std::string& str)> log_debug_callback,
-			std::function<void(const std::string& str)> log_info_callback,
-			std::function<void(const std::string& str)> log_warn_callback,
-			const LoaderResourceMonikerIDs& resourceMonikerIDs,
-			WCHAR const* native_profiler_library_filename);
+        static Loader* CreateNewLoaderInstance(
+                    ICorProfilerInfo4* pCorProfilerInfo,
+                    std::function<void(const std::string& str)> log_debug_callback,
+                    std::function<void(const std::string& str)> log_info_callback,
+                    std::function<void(const std::string& str)> log_warn_callback,
+                    const LoaderResourceMonikerIDs& resourceMonikerIDs,
+                    WCHAR const* native_profiler_library_filename,
+                    const std::vector<WSTRING>& assembliesToLoad_adDefault_procNonIIS,
+                    const std::vector<WSTRING>& assembliesToLoad_adNonDefault_procNonIIS,
+                    const std::vector<WSTRING>& assembliesToLoad_adDefault_procIIS,
+                    const std::vector<WSTRING>& assembliesToLoad_adNonDefault_procIIS);
 
-		Loader(ICorProfilerInfo4* info,
-			std::vector<WSTRING> assembly_string_default_appdomain_vector,
-			std::vector<WSTRING> assembly_string_nondefault_appdomain_vector,
-			std::function<void(const std::string& str)> log_debug_callback,
-			std::function<void(const std::string& str)> log_info_callback,
-			std::function<void(const std::string& str)> log_warn_callback,
-			const LoaderResourceMonikerIDs& resourceMonikerIDs,
-			WCHAR const* native_profiler_library_filename);
+        Loader(
+                    ICorProfilerInfo4* info,
+                    const std::vector<WSTRING>& assembly_string_default_appdomain_vector,
+                    const std::vector<WSTRING>& assembly_string_nondefault_appdomain_vector,
+                    std::function<void(const std::string& str)> log_debug_callback,
+                    std::function<void(const std::string& str)> log_info_callback,
+                    std::function<void(const std::string& str)> log_warn_callback,
+                    const LoaderResourceMonikerIDs& resourceMonikerIDs,
+                    WCHAR const* native_profiler_library_filename);
 
-		inline void Debug(const std::string& str) {
-			if (log_debug_callback_ != nullptr) {
-				log_debug_callback_(str);
-			}
-		}
+        inline void Debug(const std::string& str) {
+            if (log_debug_callback_ != nullptr) {
+                log_debug_callback_(str);
+            }
+        }
 
-		inline void Info(const std::string& str) {
-			if (log_info_callback_ != nullptr) {
-				log_info_callback_(str);
-			}
-		}
+        inline void Info(const std::string& str) {
+            if (log_info_callback_ != nullptr) {
+                log_info_callback_(str);
+            }
+        }
 
-		inline void Warn(const std::string& str) {
-			if (log_warn_callback_ != nullptr) {
-				log_warn_callback_(str);
-			}
-		}
+        inline void Warn(const std::string& str) {
+            if (log_warn_callback_ != nullptr) {
+                log_warn_callback_(str);
+            }
+        }
 
-		HRESULT WriteAssembliesStringArray(
-			ILRewriter& rewriter, const ComPtr<IMetaDataEmit2> metadata_emit,
-			const std::vector<WSTRING>& assembly_string_vector,
-			ILInstr* pFirstInstr, mdTypeRef string_type_ref);
+        HRESULT WriteAssembliesStringArray(
+                ILRewriter& rewriter, const ComPtr<IMetaDataEmit2> metadata_emit,
+                const std::vector<WSTRING>& assembly_string_vector,
+                ILInstr* pFirstInstr, mdTypeRef string_type_ref);
 
-		inline RuntimeInfo GetRuntimeInformation() {
-			COR_PRF_RUNTIME_TYPE runtime_type;
-			USHORT major_version;
-			USHORT minor_version;
-			USHORT build_version;
-			USHORT qfe_version;
+        inline RuntimeInfo GetRuntimeInformation() {
+            COR_PRF_RUNTIME_TYPE runtime_type;
+            USHORT major_version;
+            USHORT minor_version;
+            USHORT build_version;
+            USHORT qfe_version;
 
-			HRESULT hr = info_->GetRuntimeInformation(nullptr, &runtime_type, &major_version, &minor_version, &build_version, &qfe_version, 0, nullptr, nullptr);
-			if (FAILED(hr)) {
-				return {};
-			}
+            HRESULT hr = info_->GetRuntimeInformation(nullptr, &runtime_type, &major_version, &minor_version, &build_version, &qfe_version, 0, nullptr, nullptr);
+            if (FAILED(hr)) {
+                return {};
+            }
 
-			return { runtime_type, major_version, minor_version, build_version, qfe_version };
-		}
+            return { runtime_type, major_version, minor_version, build_version, qfe_version };
+        }
 
-	public:
-		
-		static void CreateNewSingeltonInstance(ICorProfilerInfo4* pCorProfilerInfo,
-                                               std::function<void(const std::string& str)> log_debug_callback,
-			                                   std::function<void(const std::string& str)> log_info_callback,
-                                               std::function<void(const std::string& str)> log_warn_callback,
-                                               const LoaderResourceMonikerIDs& resource_moniker_ids,
-			                                   WCHAR const * native_profiler_library_filename);
-		static Loader* GetSingeltonInstance();
-		static void DeleteSingeltonInstance(void);
+    public:
+        
+        static void CreateNewSingeltonInstance(
+                    ICorProfilerInfo4* pCorProfilerInfo,
+                    std::function<void(const std::string& str)> log_debug_callback,
+                    std::function<void(const std::string& str)> log_info_callback,
+                    std::function<void(const std::string& str)> log_warn_callback,
+                    const LoaderResourceMonikerIDs& resource_moniker_ids,
+                    WCHAR const * native_profiler_library_filename,
+                    const std::vector<WSTRING>& assembliesToLoad_adDefault_procNonIIS,
+                    const std::vector<WSTRING>& assembliesToLoad_adNonDefault_procNonIIS,
+                    const std::vector<WSTRING>& assembliesToLoad_adDefault_procIIS,
+                    const std::vector<WSTRING>& assembliesToLoad_adNonDefault_procIIS);
 
-		HRESULT InjectLoaderToModuleInitializer(const ModuleID module_id);
+        static Loader* GetSingeltonInstance();
+        static void DeleteSingeltonInstance(void);
 
-		bool GetAssemblyAndSymbolsBytes(void** pAssemblyArray, int* assemblySize,
-			void** pSymbolsArray, int* symbolsSize, AppDomainID appDomainId);
-	};
+        HRESULT InjectLoaderToModuleInitializer(const ModuleID module_id);
+
+        bool GetAssemblyAndSymbolsBytes(void** pAssemblyArray, int* assemblySize,
+            void** pSymbolsArray, int* symbolsSize, AppDomainID appDomainId);
+    };
 
 }  // namespace shared
 


### PR DESCRIPTION
This changes includes tweaking the assemblies to load lists so that the profiler engine is only loaded into the default App Domains. 

Partner PR from profiler repo: https://github.com/DataDog/dd-continuous-profiler-dotnet/pull/31