### PR TITLE
Loader: When the loader encounters a previously seen AppDomain, it should not log an error.

### DIFF
--- a/src/Shared-Src/Native/loader.cpp
+++ b/src/Shared-Src/Native/loader.cpp
@@ -1137,7 +1137,7 @@ namespace shared {
         // check if the loader has been already loaded for this AppDomain
         //
         if (loaders_loaded_.find(appDomainId) != loaders_loaded_.end()) {
-            Warn("Loader::GetAssemblyAndSymbolsBytes: The loader was already loaded for AppDomainID=" + ToString(appDomainId));
+            Debug("Loader::GetAssemblyAndSymbolsBytes: The loader was already loaded for AppDomainID=" + ToString(appDomainId));
             return false;
         }
 


### PR DESCRIPTION
Loader: When the loader encounters a previously seen AppDomain, it should not log an error.
This is an expected condition. That log line should be logged as Debug instead. It will otherwise confuse customers.