### PR TITLE
Delay the loading of assemblies by the loader

### DIFF
--- a/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
+++ b/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
@@ -79,7 +79,8 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
         {
             /*
              * Here we delay the loading of the assemblies to prevent a crash due to some unknown (yet) race.
-             * The case has been seen with a WCF application (client: Inovalon)
+             * The case has been seen with a WCF application.
+
              * This is a short-term fix to secure and ensure clients onboarding.
              */
             Task.Run(() =>


### PR DESCRIPTION
Currently, a customer application (Inovalon) crashes at start up. The application is a WCF application using basicHttpsBinding.
```
Message: System.Configuration.ConfigurationErrorsException: Configuration binding extension 
'system.serviceModel/bindings/basicHttpsBinding' could not be found. Verify that this binding extension 
is properly registered in system.serviceModel/extensions/bindingExtensions and that it is spelled correctly. 
(C:\SAFHIREServices\SITESiteManagementService\MRR.SiteManagement.WindowsService.exe.Config line 137)
```
It seems that delaying the loading of assemblies by the loader (Managed profiler) prevent this issue and the application perfectly runs.

THIS IS A TEMPORARY FIX

It's only meant to secure clients onboarding. The issue is still investigated (@tonyredondo  and @gleocadie )