### PR TITLE
Remove useless statement

### DIFF
--- a/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
+++ b/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
@@ -78,14 +78,13 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
         public static void Run(string[] assemblyNamesToLoadIntoDefaultAppDomain, string[] assemblyNamesToLoadIntoNonDefaultAppDomains)
         {
             /*
-             * Here we delay the loading of the assemblies to prevent a crash due to some unknown (yet) race.
+             * Here we delay (by rescheduling) the loading of the assemblies to prevent a crash due to some unknown (yet) race.
              * The case has been seen with a WCF application.
 
              * This is a short-term fix to secure and ensure clients onboarding.
              */
             Task.Run(() =>
             {
-                Task.Delay(TimeSpan.FromSeconds(1));
                 try
                 {
                     try


### PR DESCRIPTION
Remove Task.Delay since it's not awaited