### PR TITLE
Add NGEN images support in the loader

### DIFF
--- a/src/Shared-Src/Native/loader.cpp
+++ b/src/Shared-Src/Native/loader.cpp
@@ -462,8 +462,7 @@ namespace shared
 
         // Debug("  * " + ToString(typeNameString) + "." + ToString(functionNameString) + "()");
 
-        bool disableNGEN = false;
-        disableNGEN |= typeNameString == _specificTypeToInject && functionNameString == _specificMethodToInject;
+        bool disableNGEN = typeNameString == _specificTypeToInject && functionNameString == _specificMethodToInject;
 
         *pbUseCachedFunction = *pbUseCachedFunction && !disableNGEN;
         return S_OK;

--- a/src/Shared-Src/Native/loader.cpp
+++ b/src/Shared-Src/Native/loader.cpp
@@ -344,7 +344,8 @@ namespace shared
                 hr = EmitLoaderCallInMethod(moduleId, methodDef, loaderMethodDef);
                 if (SUCCEEDED(hr))
                 {
-                    Info("Loader::InjectLoaderToModuleInitializer: Loader injected successfully (in IsCompatibilitySwitchSet). [ModuleID=" + moduleIdHex +
+                    Info("Loader::InjectLoaderToModuleInitializer: Loader injected successfully (in " +
+                        ToString(_specificTypeToInject) + "." + ToString(_specificMethodToInject) + "). [ModuleID=" + moduleIdHex +
                         ", AssemblyID=" + assemblyIdHex +
                         ", AssemblyName=" + ToString(assemblyNameString) +
                         ", AppDomainID=" + appDomainIdHex +
@@ -495,8 +496,8 @@ namespace shared
         {
             Error("Loader::InjectLoaderToModuleInitializer: Call to ILRewriter.Export() failed for ModuleID=" + moduleIdHex +
                 ", methodDef=0x" + HexStr(methodDef));
-            return hr;
         }
+        return hr;
     }
 
     HRESULT Loader::EmitLoaderInModule(

--- a/src/Shared-Src/Native/loader.h
+++ b/src/Shared-Src/Native/loader.h
@@ -157,6 +157,8 @@ namespace shared
             }
         }
 
+        HRESULT EmitLoaderCallInMethod(ModuleID moduleId, mdMethodDef methodDef, mdMethodDef loaderMethodDef);
+
         HRESULT EmitLoaderInModule(
             const ComPtr<IMetaDataImport2> metadataImport,
             const ComPtr<IMetaDataEmit2> metadataEmit,
@@ -204,7 +206,7 @@ namespace shared
         }
 
     public:
-        static const DWORD LoaderProfilerEventMask = COR_PRF_DISABLE_ALL_NGEN_IMAGES | COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST;
+        static const DWORD LoaderProfilerEventMask = COR_PRF_MONITOR_JIT_COMPILATION | COR_PRF_ENABLE_REJIT | COR_PRF_MONITOR_CACHE_SEARCHES | COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST;
 
         static void CreateNewSingeltonInstance(
                     ICorProfilerInfo4* pCorProfilerInfo,
@@ -222,6 +224,7 @@ namespace shared
         static void DeleteSingeltonInstance(void);
 
         HRESULT InjectLoaderToModuleInitializer(const ModuleID moduleId);
+        HRESULT HandleFunctionSearch(FunctionID functionId, BOOL* pbUseCachedFunction);
 
         bool GetAssemblyAndSymbolsBytes(void** ppAssemblyArray, int* pAssemblySize, void** ppSymbolsArray, int* pSymbolsSize, WCHAR* pModuleName);
     };

--- a/src/Shared-Src/Native/loader.h
+++ b/src/Shared-Src/Native/loader.h
@@ -206,7 +206,7 @@ namespace shared
         }
 
     public:
-        static const DWORD LoaderProfilerEventMask = COR_PRF_MONITOR_JIT_COMPILATION | COR_PRF_ENABLE_REJIT | COR_PRF_MONITOR_CACHE_SEARCHES | COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST;
+        static const DWORD LoaderProfilerEventMask = COR_PRF_MONITOR_CACHE_SEARCHES | COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST;
 
         static void CreateNewSingeltonInstance(
                     ICorProfilerInfo4* pCorProfilerInfo,

--- a/src/Shared-Src/Native/loader.h
+++ b/src/Shared-Src/Native/loader.h
@@ -157,6 +157,13 @@ namespace shared
             }
         }
 
+        HRESULT EmitLoaderInModule(
+            const ComPtr<IMetaDataImport2> metadataImport,
+            const ComPtr<IMetaDataEmit2> metadataEmit,
+            ModuleID moduleId,
+            AppDomainID appDomainId,
+            WSTRING assemblyNameString);
+
         HRESULT EmitDDLoadInitializationAssembliesMethod(
             const ModuleID moduleId,
             mdTypeDef typeDef,

--- a/src/Shared-Src/Native/util.h
+++ b/src/Shared-Src/Native/util.h
@@ -12,6 +12,12 @@
 
 #include "string.h"
 
+#include <corhlpr.h>
+#include <corprof.h>
+#include <functional>
+#include <utility>
+#include <set>
+
 namespace shared
 {
     template <typename Out>
@@ -130,6 +136,90 @@ namespace shared
             condition_.notify_one();
         }
     };
+
+
+
+    const ULONG kEnumeratorMax = 256;
+    template <typename T>
+    class EnumeratorIterator;
+
+    template <typename T>
+    class Enumerator {
+    private:
+        const std::function<HRESULT(HCORENUM*, T[], ULONG, ULONG*)> callback_;
+        const std::function<void(HCORENUM)> close_;
+        mutable HCORENUM ptr_;
+
+    public:
+        Enumerator(std::function<HRESULT(HCORENUM*, T[], ULONG, ULONG*)> callback,
+            std::function<void(HCORENUM)> close)
+            : callback_(callback), close_(close), ptr_(nullptr) {}
+
+        Enumerator(const Enumerator& other) = default;
+
+        Enumerator& operator=(const Enumerator& other) = default;
+
+        ~Enumerator() { close_(ptr_); }
+
+        EnumeratorIterator<T> begin() const {
+            return EnumeratorIterator<T>(this, S_OK);
+        }
+
+        EnumeratorIterator<T> end() const {
+            return EnumeratorIterator<T>(this, S_FALSE);
+        }
+
+        HRESULT Next(T arr[], ULONG max, ULONG* cnt) const {
+            return callback_(&ptr_, arr, max, cnt);
+        }
+    };
+
+    template <typename T>
+    class EnumeratorIterator {
+    private:
+        const Enumerator<T>* enumerator_;
+        HRESULT status_ = S_FALSE;
+        T arr_[kEnumeratorMax]{};
+        ULONG idx_ = 0;
+        ULONG sz_ = 0;
+
+    public:
+        EnumeratorIterator(const Enumerator<T>* enumerator, HRESULT status)
+            : enumerator_(enumerator) {
+            if (status == S_OK) {
+                status_ = enumerator_->Next(arr_, kEnumeratorMax, &sz_);
+                if (status_ == S_OK && sz_ == 0) {
+                    status_ = S_FALSE;
+                }
+            }
+            else {
+                status_ = status;
+            }
+        }
+
+        bool operator!=(EnumeratorIterator const& other) const {
+            return enumerator_ != other.enumerator_ ||
+                (status_ == S_OK) != (other.status_ == S_OK);
+        }
+
+        T const& operator*() const { return arr_[idx_]; }
+
+        EnumeratorIterator<T>& operator++() {
+            if (idx_ < sz_ - 1) {
+                idx_++;
+            }
+            else {
+                idx_ = 0;
+                status_ = enumerator_->Next(arr_, kEnumeratorMax, &sz_);
+                if (status_ == S_OK && sz_ == 0) {
+                    status_ = S_FALSE;
+                }
+            }
+            return *this;
+        }
+    };
+
+
 
 }  // namespace trace
 


### PR DESCRIPTION
This PR adds NGEN images support in the loader, for that now the loader does:

1. Rewrite the `<Module>.cctor` in all modules with the loader call. (This works with all modules without NGEN images).
2. Rewrite the `System.AppDomain.IsCompatibilitySwitchSet` that gets called every time a new AppDomain is created (this handles the cases were all modules loaded in an app domain has NGEN images, eg: IIS DefaultAppDomain).
3. Handles the `JITCachedFunctionSearchStarted` profiler callback to skip NGEN images for selected methods (`System.AppDomain.IsCompatibilitySwitchSet`) in order to rewrite it and force a JIT call.
