### PR TITLE
Clean up side effects to the AppDomain.GetTargetFrameworkName() cache in the assembly loader.

### DIFF
--- a/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
+++ b/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
@@ -599,17 +599,21 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
 
         /// <summary>
         /// Clears the AppDomainSetup.TargetFrameworkName cache.
-        /// The logger used by this loader uses the Array.Sort(..) API when choosing the log file index.
-        /// The behaviour of the sort API is Framework version dependent.
-        /// It transitively uses the internal AppDomain.GetTargetFrameworkName() API.
-        /// Its value is determined by examining the TargetFrameworkAttribute on Assembly.GetEntryAssembly()
+        /// The logger used by this loader loader uses the Array.Sort(..) API when choosing the log file index.
+        /// The behavior of the sort API is Framework version dependent.
+        ///
+        /// To get the Framework version, it transitively uses the internal AppDomain.GetTargetFrameworkName() API.
+        /// The respective value is determined by examining the TargetFrameworkAttribute on Assembly.GetEntryAssembly()
         /// and then caching the result in AppDomainSetup.TargetFrameworkName.
+        ///
         /// However, because the Loader runs so early in the app lifecycle, the entry assembly may not yet be initialized (i.e. null).
-        /// In such case, the value cached in AppDomainSetup.TargetFrameworkName is also null, and it does not get updated when the
-        /// entry assembly becomes known later. This can break applications that use the target framework name to guide their behaviour
+        /// In such cases, the value cached in AppDomainSetup.TargetFrameworkName is also null, and it does not get updated when the
+        /// entry assembly becomes known later.This can break applications that use the target framework name to guide their behavior
         /// (e.g., this is known to break some WCF applications).
+        /// 
         /// This method attempts to clear the respective internal cache in AppDomainSetup.
-        /// It must be resilient to the internal API being accessed not being present (in fact, it is known not to be present on some Net Core versions).
+        /// It must be resilient to the internal API being accessed not being present
+        /// (in fact, it is known not to be present on some Net Core versions).
         /// </summary>
         private static void ClearAppDomainTargetFrameworkNameCache(bool canUseLog)
         {

--- a/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
+++ b/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
@@ -643,7 +643,7 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
                 {
                     LogDebugOrWriteLine(canUseLog,
                                         $"Cannot clean up {ThisCleanupMoniker}:"
-                                      + $" Did not find property \"{FusionStorePropertyName}\" on type \"{appDomainType.FullName}\""
+                                      + $" Did not find non-public property \"{FusionStorePropertyName}\" on type \"{appDomainType.FullName}\""
                                       + $" in assembly \"{appDomainType.Assembly?.FullName}\".");
                     return;
                 }
@@ -654,7 +654,7 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
                 {
                     LogDebugOrWriteLine(canUseLog,
                                         $"Cannot clean up {ThisCleanupMoniker}:"
-                                      + $" The value of the property \"{FusionStorePropertyName}\" on type \"{appDomainType.FullName}\""
+                                      + $" The value of the non-public property \"{FusionStorePropertyName}\" on type \"{appDomainType.FullName}\""
                                       + $" in assembly \"{appDomainType.Assembly?.FullName}\" was retrieved, but found to be null.");
                     return;
                 }
@@ -668,7 +668,7 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
                 {
                     LogDebugOrWriteLine(canUseLog,
                                         $"Cannot clean up {ThisCleanupMoniker}:"
-                                      + $" Did not find property \"{CheckedForTargetFrameworkNamePropertyName}\" on type \"{appDomainSetupType.FullName}\""
+                                      + $" Did not find non-public property \"{CheckedForTargetFrameworkNamePropertyName}\" on type \"{appDomainSetupType.FullName}\""
                                       + $" in assembly \"{appDomainType.Assembly?.FullName}\".");
                     return;
                 }

--- a/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
+++ b/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
@@ -120,7 +120,8 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
             catch
             {
                 // We still have an exception passing through the above double-catch-all. Could not even write to console.
-                // Our last choise is to let it excpe and potentially crash the process or swallow it. We prefer the later.
+                // Our last choice is to let it escape and potentially crash the process or swallow it. We prefer the latter.
+
             }
         }
 

--- a/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
+++ b/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
@@ -152,19 +152,7 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
                 Log.Error(LoggingComponentMoniker, "Error while registering an AssemblyResolve event handler", ex);
             }
 
-            var logEntryDetails = new List<object>();
-            logEntryDetails.Add("Number of assemblies");
-            logEntryDetails.Add(assemblyResolveEventHandler.AssemblyNamesToLoad.Count);
-            logEntryDetails.Add("Number of product binaries directories");
-            logEntryDetails.Add(assemblyResolveEventHandler.ManagedProductBinariesDirectories.Count);
-
-            for (int i = 0; i < assemblyResolveEventHandler.ManagedProductBinariesDirectories.Count; i++)
-            {
-                logEntryDetails.Add($"managedProductBinariesDirectories[{i}]");
-                logEntryDetails.Add(assemblyResolveEventHandler.ManagedProductBinariesDirectories[i]);
-            }
-
-            Log.Info(LoggingComponentMoniker, "Starting to load assemblies", logEntryDetails);
+            LogStartingToLoadAssembliesInfo(assemblyResolveEventHandler);
 
             for (int i = 0; i < assemblyResolveEventHandler.AssemblyNamesToLoad.Count; i++)
             {
@@ -179,6 +167,23 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
                     Log.Error(LoggingComponentMoniker, "Error loading or starting a managed assembly", ex, "assemblyName", assemblyName);
                 }
             }
+        }
+
+        private static void LogStartingToLoadAssembliesInfo(AssemblyResolveEventHandler assemblyResolveEventHandler)
+        {
+            var logEntryDetails = new List<object>();
+            logEntryDetails.Add("Number of assemblies");
+            logEntryDetails.Add(assemblyResolveEventHandler.AssemblyNamesToLoad.Count);
+            logEntryDetails.Add("Number of product binaries directories");
+            logEntryDetails.Add(assemblyResolveEventHandler.ManagedProductBinariesDirectories.Count);
+
+            for (int i = 0; i < assemblyResolveEventHandler.ManagedProductBinariesDirectories.Count; i++)
+            {
+                logEntryDetails.Add($"managedProductBinariesDirectories[{i}]");
+                logEntryDetails.Add(assemblyResolveEventHandler.ManagedProductBinariesDirectories[i]);
+            }
+
+            Log.Info(LoggingComponentMoniker, "Starting to load assemblies", logEntryDetails);
         }
 
         private static void LoadAndStartAssembly(string assemblyName)

--- a/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
+++ b/src/Shared-Libs/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
@@ -599,7 +599,8 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
 
         /// <summary>
         /// Clears the AppDomainSetup.TargetFrameworkName cache.
-        /// The logger used by this loader loader uses the Array.Sort(..) API when choosing the log file index.
+        /// The logger used by this loader uses the Array.Sort(..) API when choosing the log file index.
+
         /// The behavior of the sort API is Framework version dependent.
         ///
         /// To get the Framework version, it transitively uses the internal AppDomain.GetTargetFrameworkName() API.


### PR DESCRIPTION
This PR addresses a known customer issue with WCF applications.

The logger used by Managed Loader loader uses the Array.Sort(..) API when choosing the log file index.
The behavior of the sort API is Framework version dependent.

To get the Framework version, it transitively uses the internal AppDomain.GetTargetFrameworkName() API.
The respective value is determined by examining the TargetFrameworkAttribute on Assembly.GetEntryAssembly()
and then caching the result in AppDomainSetup.TargetFrameworkName.

However, because the Loader runs so early in the app lifecycle, the entry assembly may not yet be initialized (i.e. null).
In such cases, the value cached in AppDomainSetup.TargetFrameworkName is also null, and it does not get updated when the
entry assembly becomes known later. This can break applications that use the target framework name to guide their behavior  (e.g., this is known to break some WCF applications).

This change uses reflection to clear the private cache used by the internal AppDomain.GetTargetFrameworkName() API.
It makes assumptions about the names of the internal APIs and gracefully backs out if those internal APIs are not present.

I validated it using modified Computer Demo on Fx 4.8.
We will need to subsequently validate it with the customer AND on all supported Fx versions.