### PR TITLE
Improve performance of JitCachedFunctionSearchStarted profiler hook.

### DIFF
--- a/src/Shared-Src/Native/loader.h
+++ b/src/Shared-Src/Native/loader.h
@@ -112,6 +112,8 @@ namespace shared
         std::function<void(const std::string& str)> _logInfoCallback = nullptr;
         std::function<void(const std::string& str)> _logErrorCallback = nullptr;
 
+        FunctionID _specificMethodToInjectFunctionId;
+
         LoaderResourceMonikerIDs _resourceMonikerIDs;
 
         const WCHAR* _pNativeProfilerLibraryFilename;


### PR DESCRIPTION
The loader hooks into the `JitCachedFunctionSearchStarted` profiler callback in order to selectively disable the NGen usage for one particular method that needs to be instrumented to inject the managed loader.

This change improves the performance of that callback:

* Superfluous allocations and string conversions are removed.

* Once the function id of the target method is known, a fast path is taken, that avoids metadata loading and string comparisons and uses just 2 integer comparisons instead. In an ad-hoc test, a 15 sec execution of the Profiler's Computer demo resulted in a total of 686 invocations of `HandleJitCachedFunctionSearchStarted`, out of which 677 (=98.7%) ended up using the fast path.