### PR TITLE
Early check if debug mode is enable

### DIFF
--- a/src/Shared-Src/Native/logging.h
+++ b/src/Shared-Src/Native/logging.h
@@ -60,7 +60,7 @@ namespace shared {
 
         public:
             template <typename... Args>
-            static void Debug(const Args... args) { Logger<TLoggerPolicy>::Instance()->Debug(LogToString(args...)); }
+            static void Debug(const Args... args) { if (Logger<TLoggerPolicy>::IsDebugEnabled()) Logger<TLoggerPolicy>::Instance()->Debug(LogToString(args...)); }
             template <typename... Args>
             static void Info(const Args... args) { Logger<TLoggerPolicy>::Instance()->Info(LogToString(args...)); }
             template <typename... Args>


### PR DESCRIPTION
This early check prevents from building/formatting the message when debug mode is not enabled.