### PR TITLE
Managed Code Style changes required for the Profiler Code Styling rules.

### DIFF
--- a/src/Shared-Src/Datadog.Logging.Composition/internal/AggregatedLogSink.cs
+++ b/src/Shared-Src/Datadog.Logging.Composition/internal/AggregatedLogSink.cs
@@ -8,14 +8,14 @@ namespace Datadog.Logging.Composition
     /// <summary>
     /// Collects data from a Log-sources and sends it to many Log Sinks.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0007:Use implicit type", Justification = "Worst piece of advise Style tools ever gave.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0028:Simplify collection initialization", Justification = "Rule does not add redability")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0007:Use implicit type", Justification = "Worst piece of advise Style tools ever gave.")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0028:Simplify collection initialization", Justification = "Rule does not add redability")]
     internal sealed class AggregatedLogSink : ILogSink, IDisposable
     {
         private readonly ILogSink[] _logSinks;
 
         public AggregatedLogSink(params ILogSink[] logSinks)
-            : this((IEnumerable <ILogSink>) logSinks)
+            : this((IEnumerable<ILogSink>)logSinks)
         {
         }
 

--- a/src/Shared-Src/Datadog.Logging.Composition/internal/FileLogSink.cs
+++ b/src/Shared-Src/Datadog.Logging.Composition/internal/FileLogSink.cs
@@ -7,13 +7,13 @@ using Datadog.Logging.Emission;
 
 namespace Datadog.Logging.Composition
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1308:Variable names must not be prefixed", Justification = "Should not apply to statics")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1311:Static readonly fields must begin with upper-case letter", Justification = "Should only apply to vars that are logically const.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:Split parameters must start on line after declaration", Justification = "Bad rule")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names must not contain underscore", Justification = "Underscore aid visibility in long names")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0007:Use implicit type", Justification = "Worst piece of advise Style tools ever gave.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1615:Element return value must be documented", Justification = "That would be great.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1611:Element parameters must be documented", Justification = "That would be great.")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1308:Variable names must not be prefixed", Justification = "Should not apply to statics")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1311:Static readonly fields must begin with upper-case letter", Justification = "Should only apply to vars that are logically const.")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:Split parameters must start on line after declaration", Justification = "Bad rule")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names must not contain underscore", Justification = "Underscore aid visibility in long names")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0007:Use implicit type", Justification = "Worst piece of advise Style tools ever gave.")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1615:Element return value must be documented", Justification = "That would be great.")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1611:Element parameters must be documented", Justification = "That would be great.")]
     internal sealed class FileLogSink : ILogSink, IDisposable
     {
         public const int RotateLogFileWhenLargerBytesDefault = 1024 * 1024 * 128;  // 128 MB
@@ -113,7 +113,7 @@ namespace Datadog.Logging.Composition
                 throw new ArgumentNullException(nameof(logFileNameBase));
             }
 
-            if (string.IsNullOrWhiteSpace(logFileNameBase))
+            if (String.IsNullOrWhiteSpace(logFileNameBase))
             {
                 throw new ArgumentException($"{nameof(logFileNameBase)} may not be white-space only.", nameof(logFileNameBase));
             }
@@ -122,7 +122,7 @@ namespace Datadog.Logging.Composition
 
             newSink = null;
 
-            if (string.IsNullOrWhiteSpace(logFileDir))
+            if (String.IsNullOrWhiteSpace(logFileDir))
             {
                 return false;
             }
@@ -445,7 +445,7 @@ namespace Datadog.Logging.Composition
                         return false;
 
                     default:
-                        throw new InvalidOperationException($"Unexpected OS PlatformID: \"{platformID}\" ({((int) platformID)})");
+                        throw new InvalidOperationException($"Unexpected OS PlatformID: \"{platformID}\" ({((int)platformID)})");
                 }
             }
             catch
@@ -468,7 +468,7 @@ namespace Datadog.Logging.Composition
                 catch
                 { }
             }
-            
+
             return false;
         }
 

--- a/src/Shared-Src/Datadog.Logging.Composition/internal/LogEventHandlersToLogSinkAdapter.cs
+++ b/src/Shared-Src/Datadog.Logging.Composition/internal/LogEventHandlersToLogSinkAdapter.cs
@@ -38,7 +38,7 @@ namespace Datadog.Logging.Composition
                                                          logSourceCallLineNumber,
                                                          logSourceCallMemberName,
                                                          logSourceCallFileName,
-                                                         logSourceAssemblyName), 
+                                                         logSourceAssemblyName),
                                        message,
                                        exception,
                                        dataNamesAndValues);

--- a/src/Shared-Src/Datadog.Logging.Composition/internal/LogGroupMutex.cs
+++ b/src/Shared-Src/Datadog.Logging.Composition/internal/LogGroupMutex.cs
@@ -30,7 +30,7 @@ namespace Datadog.Logging.Composition
         private string _mutexName;
         private Mutex _mutex;
 
-#region struct LogGroupMutex.Handle
+        #region struct LogGroupMutex.Handle
         public struct Handle : IDisposable
         {
             internal static readonly Handle InvalidInstance = new Handle(null, null);
@@ -92,7 +92,7 @@ namespace Datadog.Logging.Composition
                 }
             }
         }
-#endregion struct LogGroupMutex.Handle
+        #endregion struct LogGroupMutex.Handle
 
         public LogGroupMutex(Guid logGroupId)
         {
@@ -165,7 +165,7 @@ namespace Datadog.Logging.Composition
                     }
 
                     SafeDisposeAndSetToNull(ref _mutex);
-                    _mutexName = string.Empty;
+                    _mutexName = String.Empty;
                     Interlocked.Exchange(ref _iteration, -1);
                 }
                 finally
@@ -181,7 +181,8 @@ namespace Datadog.Logging.Composition
 
         private static string ConstructMutextName(Guid groupId, int iteration)
         {
-            return $"Global\\Datadog-FileLigSink-{groupId.ToString("D")}-{iteration}";
+            string groupIdString = groupId.ToString("D");
+            return $"Global\\Datadog-FileLigSink-{groupIdString}-{iteration}";
         }
 
         private static bool TryAcquireCore(Mutex mutex, SemaphoreSlim mutexProtector, ref LogGroupMutex.Handle handle)
@@ -229,7 +230,11 @@ namespace Datadog.Logging.Composition
                             return true;
                         }
 
-                        rnd = rnd ?? new Random();
+                        if (rnd == null)
+                        {
+                            rnd = new Random();
+                        }
+
                         Thread.Sleep(rnd.Next(MaxPauseBetweenWaitsMillis));
 
                         int now = Environment.TickCount & Int32.MaxValue;

--- a/src/Shared-Src/Datadog.Logging.Composition/internal/SimpleConsoleLogSink.cs
+++ b/src/Shared-Src/Datadog.Logging.Composition/internal/SimpleConsoleLogSink.cs
@@ -27,7 +27,7 @@ namespace Datadog.Logging.Composition
             {
                 return false;
             }
-            
+
         }
 
         public bool TryLogInfo(LogSourceInfo logSourceInfo, string message, IEnumerable<object> dataNamesAndValues)

--- a/src/Shared-Src/Datadog.Logging.Emission/internal/DefaultFormat.cs
+++ b/src/Shared-Src/Datadog.Logging.Emission/internal/DefaultFormat.cs
@@ -5,11 +5,11 @@ using System.Text;
 
 namespace Datadog.Logging.Emission
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1308:Variable names must not be prefixed", Justification = "Should not apply to statics")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1311:Static readonly fields must begin with upper-case letter", Justification = "Should only apply to vars that are logically const.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:Split parameters must start on line after declaration", Justification = "Bad rule")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names must not contain underscore", Justification = "Underscore aid visibility in long names")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0007:Use implicit type", Justification = "Worst piece of advise Style tools ever gave.")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1308:Variable names must not be prefixed", Justification = "Should not apply to statics")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1311:Static readonly fields must begin with upper-case letter", Justification = "Should only apply to vars that are logically const.")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:Split parameters must start on line after declaration", Justification = "Bad rule")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names must not contain underscore", Justification = "Underscore aid visibility in long names")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0007:Use implicit type", Justification = "Worst piece of advise Style tools ever gave.")]
     internal static class DefaultFormat
     {
         public class Options
@@ -124,7 +124,7 @@ namespace Datadog.Logging.Emission
             {
                 hasEncounteredNewLines = false;
                 int p = 0;
-                while(p < srcText.Length)
+                while (p < srcText.Length)
                 {
                     char c = srcText[p];
                     if (c == '\n' || c == '\r')
@@ -230,7 +230,7 @@ namespace Datadog.Logging.Emission
                     return;
                 }
 
-                targetBuffer.Append("[");
+                targetBuffer.Append('[');
                 AppendPrefixCore(targetBuffer, logLevelMoniker, useUtcTimestamp);
                 targetBuffer.Append("] ");
             }
@@ -264,6 +264,7 @@ namespace Datadog.Logging.Emission
                 }
             }
 
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "@ToDo review")]
             public static void AppendEventInfo(StringBuilder targetBuffer,
                                                string logSourceNamePart1,
                                                string logSourceNamePart2,
@@ -275,8 +276,8 @@ namespace Datadog.Logging.Emission
                                                IEnumerable<object> dataNamesAndValues,
                                                bool useNewLines)
             {
-                bool hasLogSourceNamePart1 = !string.IsNullOrWhiteSpace(logSourceNamePart1);
-                bool hasLogSourceNamePart2 = !string.IsNullOrWhiteSpace(logSourceNamePart2);
+                bool hasLogSourceNamePart1 = !String.IsNullOrWhiteSpace(logSourceNamePart1);
+                bool hasLogSourceNamePart2 = !String.IsNullOrWhiteSpace(logSourceNamePart2);
 
                 if (hasLogSourceNamePart1)
                 {
@@ -298,7 +299,7 @@ namespace Datadog.Logging.Emission
                     targetBuffer.Append(": ");
                 }
 
-                if (!string.IsNullOrWhiteSpace(message))
+                if (false == String.IsNullOrWhiteSpace(message))
                 {
                     targetBuffer.Append(message);
 

--- a/src/Shared-Src/Datadog.Logging.Emission/internal/LogSourceInfo.cs
+++ b/src/Shared-Src/Datadog.Logging.Emission/internal/LogSourceInfo.cs
@@ -71,12 +71,12 @@ namespace Datadog.Logging.Emission
             {
                 return WithLogSourcesName(null, superGroupName);
             }
-            
+
             if (LogSourceNamePart1 == null && LogSourceNamePart2 != null)
             {
                 return WithLogSourcesName(superGroupName, LogSourceNamePart2);
             }
-            
+
             if (LogSourceNamePart1 != null && LogSourceNamePart2 == null)
             {
                 return WithLogSourcesName(superGroupName, LogSourceNamePart1);

--- a/src/Shared-Src/Datadog.Logging.Emission/internal/SimpleConsoleSink.cs
+++ b/src/Shared-Src/Datadog.Logging.Emission/internal/SimpleConsoleSink.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 
 namespace Datadog.Logging.Emission
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0007:Use implicit type", Justification = "Worst piece of advise Style tools ever gave.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:Split parameters must start on line after declaration", Justification = "Bad rule")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0007:Use implicit type", Justification = "Worst piece of advise Style tools ever gave.")]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:Split parameters must start on line after declaration", Justification = "Bad rule")]
     internal static class SimpleConsoleSink
     {
         private static readonly DefaultFormat.Options FormatOptions = DefaultFormat.Options.StructuredMultilines;

--- a/src/Shared-Src/Datadog.Util/internal/Concurrent.cs
+++ b/src/Shared-Src/Datadog.Util/internal/Concurrent.cs
@@ -66,7 +66,7 @@ namespace Datadog.Util
         /// <param name="comparand"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T CompareExchangeResult<T>(ref T storageLocation, T value,T comparand) where T : class
+        public static T CompareExchangeResult<T>(ref T storageLocation, T value, T comparand) where T : class
         {
             T prevValue = Interlocked.CompareExchange(ref storageLocation, value, comparand);
             return Object.ReferenceEquals(prevValue, comparand) ? value : prevValue;

--- a/src/Shared-Src/Datadog.Util/internal/Converter.cs
+++ b/src/Shared-Src/Datadog.Util/internal/Converter.cs
@@ -13,17 +13,20 @@ namespace Datadog.Util
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static DateTimeOffset ToDateTimeOffset(long unixTimeUtcSeconds)
             {
-                #if NET45
-                    return ToDateTimeOffsetImplementation(unixTimeUtcSeconds);
-                #elif NET451
-                    return ToDateTimeOffsetImplementation(unixTimeUtcSeconds);
-                #elif NET452
-                    return ToDateTimeOffsetImplementation(unixTimeUtcSeconds);
-                #else
-                    return DateTimeOffset.FromUnixTimeSeconds(unixTimeUtcSeconds);
-                #endif
+#if NET45
+                return ToDateTimeOffsetImplementation(unixTimeUtcSeconds);
+#elif NET451
+                return ToDateTimeOffsetImplementation(unixTimeUtcSeconds);
+#elif NET452
+                return ToDateTimeOffsetImplementation(unixTimeUtcSeconds);
+#else
+                return DateTimeOffset.FromUnixTimeSeconds(unixTimeUtcSeconds);
+#endif
             }
 
+#pragma warning disable IDE0079  // Remove unnecessary suppression, as it is necessary for some targets
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0051: Remove unused private member", Justification = "Used in some, but not all compilation targets")]
+#pragma warning restore IDE0079  // Remove unnecessary suppression
             private static DateTimeOffset ToDateTimeOffsetImplementation(long unixTimeUtcSeconds)
             {
                 // Precomputed:
@@ -34,7 +37,7 @@ namespace Datadog.Util
 
                 if (unixTimeUtcSeconds < MinSeconds || unixTimeUtcSeconds > MaxSeconds)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(unixTimeUtcSeconds), 
+                    throw new ArgumentOutOfRangeException(nameof(unixTimeUtcSeconds),
                                                           $"Valid values are between {MinSeconds} and {MaxSeconds} seconds, inclusive.");
                 }
 

--- a/src/Shared-Src/Datadog.Util/internal/ExceptionAggregator.cs
+++ b/src/Shared-Src/Datadog.Util/internal/ExceptionAggregator.cs
@@ -53,7 +53,7 @@ namespace Datadog.Util
     ///     }
     /// </code>
     /// </summary>
-    /// <remarks>This type is a <c>ref struct</c> rather than a simple <c>struct</c> because it is a non-imutable value type.
+    /// <remarks>This type is a <c>ref struct</c> rather than a simple <c>struct</c> because it is a non-immutable value type.
     /// Being a <c>ref struct</c> prevents it from being unintentionally boxed (such a boxed copy may be torn-modified).</remarks>
     internal ref struct ExceptionAggregator
     {

--- a/src/Shared-Src/Datadog.Util/internal/ExceptionExtensions.cs
+++ b/src/Shared-Src/Datadog.Util/internal/ExceptionExtensions.cs
@@ -24,7 +24,7 @@ namespace Datadog.Util
         /// 'missing initialization' and similar.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Exception Rethrow(this Exception exception) 
+        public static Exception Rethrow(this Exception exception)
         {
             if (exception == null)
             {

--- a/src/Shared-Src/Datadog.Util/internal/Format.cs
+++ b/src/Shared-Src/Datadog.Util/internal/Format.cs
@@ -10,8 +10,8 @@ namespace Datadog.Util
         private const string NullWord = "null";
 
         private const string HundredSpaces = "                                                                                                    ";
-        private const string TenSpaces =     "          ";
-        private const string OneSpace =      " ";
+        private const string TenSpaces = "          ";
+        private const char OneSpace = ' ';
 
         /// <summary>
         /// Returns either the specified <c>str</c> instrance, or the string <c>"null"</c> if <c>str</c> was <c>null</c>.

--- a/src/Shared-Src/Datadog.Util/internal/HResult.cs
+++ b/src/Shared-Src/Datadog.Util/internal/HResult.cs
@@ -3,8 +3,10 @@ using System.Text;
 
 namespace Datadog.Util
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0049:Simplify Names", Justification = "Uses Framework type names for correspondance with native types.")]
     public static class HResult
     {
+#pragma warning disable IDE1006  // Non-CodeStyle-conform names required here {
         public const UInt32 S_OK = 0x00000000;
         public const UInt32 E_ABORT = 0x80004004;               // Operation aborted
         public const UInt32 E_FAIL = 0x80004005;                // Unspecified failure
@@ -19,6 +21,7 @@ namespace Datadog.Util
         public const UInt32 E_CHANGED_STATE = 0x8000000C;       // A concurrent operation changed the state of the object, invalidating this operation.
         public const UInt32 E_ILLEGAL_STATE_CHANGE = 0x8000000D;// An illegal state change was requested.
         public const UInt32 E_ILLEGAL_METHOD_CALL = 0x8000000E; // A method was called at an unexpected time.
+#pragma warning restore IDE1006  // } Non-CodeStyle-conform names required here
 
         private const UInt32 SeverityBitMask = 0x80000000;
 
@@ -50,23 +53,56 @@ namespace Datadog.Util
         {
             switch (hr)
             {
-                case S_OK:                      return "S_OK";
-                case E_ABORT:                   return "E_ABORT";
-                case E_FAIL:                    return "E_FAIL";
-                case E_NOTIMPL:                 return "E_NOTIMPL";
-                case E_POINTER:                 return "E_POINTER";
-                case E_UNEXPECTED:              return "E_UNEXPECTED";
-                case E_OUTOFMEMORY:             return "E_OUTOFMEMORY";
-                case E_INVALIDARG:              return "E_INVALIDARG";
-                case E_ACCESSDENIED:            return "E_ACCESSDENIED";
-                case E_PENDING:                 return "E_PENDING";
-                case E_BOUNDS:                  return "E_BOUNDS";
-                case E_CHANGED_STATE:           return "E_CHANGED_STATE";
-                case E_ILLEGAL_STATE_CHANGE:    return "E_ILLEGAL_STATE_CHANGE";
-                case E_ILLEGAL_METHOD_CALL:     return "E_ILLEGAL_METHOD_CALL";
+                case S_OK:
+                    return "S_OK";
+
+                case E_ABORT:
+                    return "E_ABORT";
+                case E_FAIL:
+                    return "E_FAIL";
+
+                case E_NOTIMPL:
+                    return "E_NOTIMPL";
+
+                case E_POINTER:
+                    return "E_POINTER";
+
+                case E_UNEXPECTED:
+                    return "E_UNEXPECTED";
+
+                case E_OUTOFMEMORY:
+                    return "E_OUTOFMEMORY";
+
+                case E_INVALIDARG:
+                    return "E_INVALIDARG";
+
+                case E_ACCESSDENIED:
+                    return "E_ACCESSDENIED";
+
+                case E_PENDING:
+                    return "E_PENDING";
+
+                case E_BOUNDS:
+                    return "E_BOUNDS";
+
+                case E_CHANGED_STATE:
+                    return "E_CHANGED_STATE";
+
+                case E_ILLEGAL_STATE_CHANGE:
+                    return "E_ILLEGAL_STATE_CHANGE";
+
+                case E_ILLEGAL_METHOD_CALL:
+                    return "E_ILLEGAL_METHOD_CALL";
+
                 default:
-                    if (IsSuccess(hr))          return "UnknownCode_Success";
-                    else                        return "UnknownCode_Failure";
+                    if (IsSuccess(hr))
+                    {
+                        return "UnknownCode_Success";
+                    }
+                    else
+                    {
+                        return "UnknownCode_Failure";
+                    }
             }
         }
 
@@ -80,12 +116,12 @@ namespace Datadog.Util
             var s = new StringBuilder(ToString(hr));
             s.Append(" (0x");
             s.Append(hr.ToString("X8"));
-            s.Append(")");
+            s.Append(')');
             return s.ToString();
         }
 
         public static UInt32 GetFailureCode(Exception ex)
-        { 
+        {
             if (ex == null)
             {
                 return HResult.E_FAIL;

--- a/src/Shared-Src/Datadog.Util/internal/RuntimeEnvironmentInfo.cs
+++ b/src/Shared-Src/Datadog.Util/internal/RuntimeEnvironmentInfo.cs
@@ -1,13 +1,16 @@
 ﻿#if NETCOREAPP || NETSTANDARD
+
 #define RUNTIMEINFORMATION_TYPE_AVAILABLE
+
 #endif
 
-using Datadog.Util;
 using System;
 using System.Reflection;
 
 #if RUNTIMEINFORMATION_TYPE_AVAILABLE
-    using System.Runtime.InteropServices;
+
+using System.Runtime.InteropServices;
+
 #endif
 
 namespace Datadog.Util
@@ -48,7 +51,7 @@ namespace Datadog.Util
                 RuntimeEnvironmentInfo singeltonInstance = s_singeltonInstance;
                 if (singeltonInstance == null)
                 {
-                    singeltonInstance = CreateNew();    
+                    singeltonInstance = CreateNew();
                     s_singeltonInstance = singeltonInstance;    // benign race
                 }
 
@@ -152,7 +155,7 @@ namespace Datadog.Util
             }
 
             string assemblyInfoVer = objectTypeAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-            
+
             if (assemblyInfoVer != null)
             {
                 // Strip the git hash if there is one:
@@ -166,7 +169,7 @@ namespace Datadog.Util
                 int minusIndex = assemblyInfoVer.IndexOf('-');
                 if (minusIndex >= 0)
                 {
-                    assemblyInfoVer = assemblyInfoVer.Substring(0, plusIndex);
+                    assemblyInfoVer = assemblyInfoVer.Substring(0, minusIndex);
                 }
 
                 string runtimeVersion = assemblyInfoVer.Trim();
@@ -220,7 +223,7 @@ namespace Datadog.Util
         {
 #if RUNTIMEINFORMATION_TYPE_AVAILABLE
             string osDescription = RuntimeInformation.OSDescription;
-            if (! String.IsNullOrWhiteSpace(osDescription))
+            if (false == String.IsNullOrWhiteSpace(osDescription))
             {
                 return osDescription;
             }
@@ -231,7 +234,7 @@ namespace Datadog.Util
 #if RUNTIMEINFORMATION_TYPE_AVAILABLE
         private static string ArchitectureToString(Architecture architecture)
         {
-            switch(architecture)
+            switch (architecture)
             {
                 case Architecture.X86:
                     return "x86";
@@ -289,7 +292,7 @@ namespace Datadog.Util
             {
                 stringView = $"{RuntimeName} {RuntimeVersion} ({ProcessArchitecture}) running on {OsPlatform} {OsArchitecture}";
 
-                if (! String.IsNullOrWhiteSpace(OsDescription))
+                if (!String.IsNullOrWhiteSpace(OsDescription))
                 {
                     stringView = $"{stringView} ({OsDescription})";
                 }

--- a/src/Shared-Src/Datadog.Util/internal/Validate.cs
+++ b/src/Shared-Src/Datadog.Util/internal/Validate.cs
@@ -58,7 +58,7 @@ namespace Datadog.Util
         {
             NotNullOrEmpty(value, name);
 
-            if (string.IsNullOrWhiteSpace(value))
+            if (String.IsNullOrWhiteSpace(value))
             {
                 throw new ArgumentException((name ?? Validate.FallbackParameterName) + " may not be whitespace only.");
             }


### PR DESCRIPTION
Files affected by this change are currently only used by the Profiler.

The Profiler formalizes its coding style rules (https://github.com/DataDog/dd-continuous-profiler-dotnet/pull/126) and this applies to some files in this repo as well.

No functional change.